### PR TITLE
Better detectors

### DIFF
--- a/Syntaxes/Liquid-HTML.xml
+++ b/Syntaxes/Liquid-HTML.xml
@@ -9,7 +9,8 @@
 
 	<detectors>
 		<extension priority="1.0">liquid</extension>
-		<extension priority="2.0">html</extension>
+		<extension priority="0.5">html</extension>
+		<match-content lines="100" priority="0.9">{%</match-content>
 	</detectors>
 
 	<indentation>


### PR DESCRIPTION
Improved extension detectors — changed priority for `html` to 0.5 (because a valid value is between 0 to 1), and added a content-match rule. The content-matcher finds `{%` in the top 100 lines. Works great for my liquid files in extension `html`.